### PR TITLE
表示名の設定

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,6 +14,7 @@ gem 'rails-i18n', '~> 6.0'
 gem 'sass-rails', '>= 6'
 gem 'turbolinks', '~> 5'
 gem 'webpacker', '~> 5.0'
+gem 'enum_help'
 
 group :development, :test do
   gem 'byebug', platforms: %i[mri mingw x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -77,6 +77,8 @@ GEM
       warden (~> 1.2.3)
     devise-i18n (1.9.3)
       devise (>= 4.7.1)
+    enum_help (0.0.17)
+      activesupport (>= 3.0.0)
     erubi (1.10.0)
     ffi (1.15.0)
     globalid (0.4.2)
@@ -214,6 +216,7 @@ DEPENDENCIES
   byebug
   devise
   devise-i18n
+  enum_help
   jbuilder (~> 2.7)
   listen (~> 3.3)
   pg (~> 1.1)

--- a/config/locales/enums.ja.yml
+++ b/config/locales/enums.ja.yml
@@ -1,0 +1,12 @@
+ja:
+  enums:
+    text:
+      genre: &genre
+        invisible: '非表示'
+        basic: 'Basic'
+        git: 'Git'
+        ruby: 'Ruby'
+        rails: 'Ruby on Rails'
+        php: 'PHP'
+    movie:
+      genre: *genre


### PR DESCRIPTION

close #10

## 実装内容

- `enum-help` を追加
- `texts`, `movies` テーブルの `genre` に対応する表示名 `config/locales/enums.ja.yml` に追加
    -  表示名の設定は `db/csv_data/genre_data.csv` を参考にして下さい
    -  YAML の アンカー（`&`）, エイリアス（`*`）を利用して重複を回避すること



##動作確認
- 以下を実行し，教材データが入っていることを確認
```
rails c

# Railsコンソール起動後
Text.genres_i18n
Movie.genres_i18n
```


## チェックリスト


- [x] GitHub で Files changed を確認
- [x] 影響し得る範囲のローカル環境での動作確認

