### PR TITLE
フラッシュの実装

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -28,3 +28,12 @@
 .mw-xl {
   max-width: 1200px;
 }
+
+// フラッシュ
+.alert-notice {
+  @extend .alert-success;
+}
+
+.alert-alert {
+  @extend .alert-danger;
+}

--- a/app/controllers/texts_controller.rb
+++ b/app/controllers/texts_controller.rb
@@ -1,5 +1,6 @@
 class TextsController < ApplicationController
   def index
+    # flash[:notice] = "ログインしました。"
   end
 
   def show

--- a/app/views/layouts/_flash.html.erb
+++ b/app/views/layouts/_flash.html.erb
@@ -1,0 +1,4 @@
+<% flash.each do |flash_type, msg| %>
+  <p style="color: <%= flash_type == 'notice' ? 'green' : 'red' %>;"><%= msg %></p>
+  <hr>
+  <% end %>

--- a/app/views/layouts/_flash.html.erb
+++ b/app/views/layouts/_flash.html.erb
@@ -1,4 +1,6 @@
 <% flash.each do |flash_type, msg| %>
-  <p style="color: <%= flash_type == 'notice' ? 'green' : 'red' %>;"><%= msg %></p>
-  <hr>
-  <% end %>
+  <div class="alert alert-<%= flash_type %>" role="alert">
+    <a href="#" class="close" data-dismiss="alert">×</a>
+    <%= msg %>
+  </div>
+<% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -13,6 +13,7 @@
       <%= render "layouts/header" %>
     </header>
     <main>
+      <%= render "layouts/flash" %>
       <%# max_width メソッドは application_helper.rb に記載 %>
       <div class="base-container <%= max_width %>">
         <%= yield %>


### PR DESCRIPTION
close #12 

## 実装内容

- フラッシュの表示機能
  - ナビバー同様, 横幅一杯とした
  - 部分テンプレート`app/views/layouts/_flash.html.erb`を作成
- フラッシュの背景色を設定
  - Bootstrapを利用
  - `notice`は`alert-success`, `alert`は`alert-danger`とした

## 参考資料
- [【公式】Bootstrap(Alerts)](https://getbootstrap.jp/docs/4.5/components/alerts/)
- [【やんばるエキスパート教材】メッセージ投稿アプリ その3](https://www.yanbaru-code.com/texts/271)

## チェックリスト

- [x] GitHub で Files changed を確認
- [x] 影響し得る範囲のローカル環境での動作確認
