### PR TITLE
Railsテキスト教材一覧ページの実装

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -3,7 +3,7 @@
  *= require_self
  */
 
-@import "bootstrap/scss/bootstrap";
+@import 'bootstrap/scss/bootstrap';
 /* 全体 */
 
 .base-container {

--- a/app/assets/stylesheets/texts.scss
+++ b/app/assets/stylesheets/texts.scss
@@ -18,9 +18,3 @@
 img {
   max-width: 100%;
 }
-
-.card-body {
-  flex: 1 1 auto;
-  min-height: 1px;
-  padding: 1.25rem;
-}

--- a/app/assets/stylesheets/texts.scss
+++ b/app/assets/stylesheets/texts.scss
@@ -1,4 +1,8 @@
 // テキスト教材カード
+.text-title {
+  margin: 0 auto;
+}
+
 .card-box {
   margin: 0 auto;
   padding-right: 15px;
@@ -6,9 +10,17 @@
 }
 
 .card {
-  height: 360px;
+  height: 370px;
+  max-width: 376px;
+  margin: 0 auto;
 }
 
 img {
   max-width: 100%;
+}
+
+.card-body {
+  flex: 1 1 auto;
+  min-height: 1px;
+  padding: 1.25rem;
 }

--- a/app/assets/stylesheets/texts.scss
+++ b/app/assets/stylesheets/texts.scss
@@ -1,0 +1,14 @@
+// テキスト教材カード
+.card-box {
+  margin: 0 auto;
+  padding-right: 15px;
+  padding-left: 15px;
+}
+
+.card {
+  height: 360px;
+}
+
+img {
+  max-width: 100%;
+}

--- a/app/assets/stylesheets/texts.scss
+++ b/app/assets/stylesheets/texts.scss
@@ -1,6 +1,7 @@
 // テキスト教材カード
 .text-title {
   margin: 0 auto;
+  text-align: center;
 }
 
 .card-box {
@@ -9,12 +10,13 @@
   padding-left: 15px;
 }
 
-.card {
+.content-card {
   height: 370px;
   max-width: 376px;
   margin: 0 auto;
 }
 
-img {
+.img-fluid {
   max-width: 100%;
+  height: auto;
 }

--- a/app/controllers/texts_controller.rb
+++ b/app/controllers/texts_controller.rb
@@ -1,5 +1,8 @@
+
 class TextsController < ApplicationController
   def index
+    # @texts = Text.all
+    @texts = Text.where(genre: ["basic", "git", "ruby", "rails"])
   end
 
   def show

--- a/app/controllers/texts_controller.rb
+++ b/app/controllers/texts_controller.rb
@@ -1,8 +1,7 @@
 
 class TextsController < ApplicationController
   def index
-    # @texts = Text.all
-    @texts = Text.where(genre: ["basic", "git", "ruby", "rails"])
+    @texts = Text.where(genre: Text::RAILS_GENRE_LIST)
   end
 
   def show

--- a/app/models/text.rb
+++ b/app/models/text.rb
@@ -14,5 +14,5 @@ class Text < ApplicationRecord
     php: 5
   }
   
-  RAILS_GENRE_LIST = %w[basic git ruby rails]
+  RAILS_GENRE_LIST = %w[basic git ruby rails].freeze
 end

--- a/app/models/text.rb
+++ b/app/models/text.rb
@@ -13,5 +13,6 @@ class Text < ApplicationRecord
     rails: 4,
     php: 5
   }
-
+  
+  RAILS_GENRE_LIST = %w[basic git ruby rails]
 end

--- a/app/views/texts/_text.html.erb
+++ b/app/views/texts/_text.html.erb
@@ -1,0 +1,16 @@
+<div class="text-container">
+  <div class="row">
+    <div class="card-box col-12 col-md-6 col-lg-4">
+      <div class="card content-card border-dark mb-3">
+        <div class="bd-placeholder-img card-img-top">
+          <img src="https://d5izmuz0mcjzz.cloudfront.net/texts/no_image.jpg" alt="デフォルト画像">
+        </div>
+        <div class="card-body">
+          <a href="#" class="btn btn-secondary btn-block">読破済みにする</a>
+          <h5 class="card-title"><%= text.title %></h5>
+          <p class="card-genre">【<%= text.genre %>】</p>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/texts/_text.html.erb
+++ b/app/views/texts/_text.html.erb
@@ -1,16 +1,12 @@
-<div class="text-container">
-  <div class="row">
-    <div class="card-box col-12 col-md-6 col-lg-4">
-      <div class="card content-card border-dark mb-3">
-        <div class="bd-placeholder-img card-img-top">
-          <img src="https://d5izmuz0mcjzz.cloudfront.net/texts/no_image.jpg" alt="デフォルト画像">
-        </div>
-        <div class="card-body">
-          <a href="#" class="btn btn-secondary btn-block">読破済みにする</a>
-          <h5 class="card-title"><%= text.title %></h5>
-          <p class="card-genre">【<%= text.genre %>】</p>
-        </div>
-      </div>
+<div class="card-box col-12 col-md-6 col-lg-4">
+  <div class="card content-card border-dark mb-3">
+    <div class="bd-placeholder-img card-img-top">
+      <img src="https://d5izmuz0mcjzz.cloudfront.net/texts/no_image.jpg" alt="デフォルト画像">
+    </div>
+    <div class="card-body">
+      <a href="#" class="btn btn-secondary btn-block">読破済みにする</a>
+      <h5 class="card-title mt-3"><%= text.title %></h5>
+      <p class="card-genre">【<%= text.genre %>】</p>
     </div>
   </div>
 </div>

--- a/app/views/texts/_text.html.erb
+++ b/app/views/texts/_text.html.erb
@@ -1,7 +1,7 @@
 <div class="card-box col-12 col-md-6 col-lg-4">
   <div class="card content-card border-dark mb-3">
-    <div class="bd-placeholder-img card-img-top">
-      <img src="https://d5izmuz0mcjzz.cloudfront.net/texts/no_image.jpg" alt="デフォルト画像">
+    <div class="card-header p-0">
+      <img loading="lazy" alt="<%= text.title %>" class="img-fluid" src="https://d5izmuz0mcjzz.cloudfront.net/texts/no_image.jpg">
     </div>
     <div class="card-body">
       <a href="#" class="btn btn-secondary btn-block">読破済みにする</a>

--- a/app/views/texts/index.html.erb
+++ b/app/views/texts/index.html.erb
@@ -1,1 +1,2 @@
-
+<h1 class="text-center">Ruby/Railsテキスト教材</h1>
+<%= render partial: "text", collection: @texts %>

--- a/app/views/texts/index.html.erb
+++ b/app/views/texts/index.html.erb
@@ -1,2 +1,9 @@
-<h1 class="text-center">Ruby/Railsテキスト教材</h1>
-<%= render partial: "text", collection: @texts %>
+<div class="container">
+  <div class="row">
+    <h1 class="text-title mt-2 mb-4">Ruby/Rails <br class="d-sm-none">
+      テキスト教材</h1>
+  </div>
+</div>
+<div class="row">
+  <%= render partial: "text", collection: @texts %>
+</div>


### PR DESCRIPTION
close #13

## 実装内容
#8 #9 #10 完了後に行ってください
- `app/models/text.rb` に次を定義
```  rb
RAILS_GENRE_LIST = %w[basic git ruby rails]
```
- Railsテキスト教材の一覧ページを作成
  * 表示するジャンルは `Text::RAILS_GENRE_LIST` に制限
  * Bootstrapの `Cards` や `Grid System` を用いて下図のようなスタイルにすること
  * `each`を使わず「[コレクションをレンダリング](https://railsguides.jp/layouts_and_rendering.html)」を利用しましょう
  * 画像部分は [デフォルト画像](https://d5izmuz0mcjzz.cloudfront.net/texts/no_image.jpg) を表示するのみとする
  * カードの `height`, `max-width` を指定すること
  * テキスト教材ページでしか利用しないスタイルは `app/assets/stylesheets/texts.scss` を作成して書き込むこと
  * 検索機能は実装しない
  * 広告は実装しない
  * カード全体を「詳細ページ」へのリンクにする作業は別タスクとする
  * 「読破済みボタン」はボタンの配置のみとする。（機能は別タスクで実装）
  
![image](https://user-images.githubusercontent.com/80580429/116790213-166b4800-aaee-11eb-980e-0fb54dff6cec.png)
![image](https://user-images.githubusercontent.com/80580429/116790314-6cd88680-aaee-11eb-9394-8b64f418b50e.png)
![image](https://user-images.githubusercontent.com/80580429/116790326-782bb200-aaee-11eb-8623-bab4434a6f4e.png)
## 参考文献
- [【公式】Bootstrap Cards](https://getbootstrap.jp/docs/4.5/components/card/)
- [【公式】Bootstrap Grid system](https://getbootstrap.jp/docs/4.5/layout/grid/)
## 動作確認
- 画像のようにレスポンシブ対応ができているかどうかを確認
- ブラウザの横幅次第でカードの横幅が長くなりすぎていないか確認
- PHPのテキスト教材が表示されていないことを確認

原則，マークダウン記法のリストで記載すること

(例)

- リスト1
  - リスト1-1
  - リスト1-2  

## 参考資料（必要があれば）

マークダウン記法のリンクを用いて記載すること

(例)

- ログイン機能
  - [やんばるエキスパートアプリ](https://www.yanbaru-code.com/texts/219)

## チェックリスト

【補足】プルリクを出した後，クリックしてチェックを入れて下さい

- [x] GitHub で Files changed を確認
- [x] 影響し得る範囲のローカル環境での動作確認

## スクリーンショット（必要があれば）


## 備考（必要があれば）
