### PR TITLE
ゲストログイン機能を実装、ナビバーと「ログイン・新規登録のページ」に配置

### DIFF
--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -1,0 +1,8 @@
+class Users::SessionsController < Devise::SessionsController
+  def guest_sign_in
+    # ゲストアカウントでログイン
+    sign_in User.guest
+    # トップページへリダイレクト
+    redirect_to root_path, notice: "ゲストユーザーとしてログインしました。"
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,4 +3,10 @@ class User < ApplicationRecord
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
          :rememberable, :validatable
+
+  def self.guest
+    find_or_create_by!(email: "test@example.com") do |user|
+      user.password = SecureRandom.urlsafe_base64
+    end
+  end
 end

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -1,37 +1,27 @@
 <h1>アカウント編集</h1>
-
 <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
   <%= bootstrap_devise_error_messages! %>
-
   <div class="form-group">
     <%= f.label :email %>
     <%= f.email_field :email, autofocus: true, autocomplete: 'email', class: 'form-control' %>
   </div>
-
   <div class="form-group">
     <%= f.label :password %>
     <%= f.password_field :password, autocomplete: 'new-password', class: 'form-control' %>
-
     <small class="form-text text-muted"><%= t('.leave_blank_if_you_don_t_want_to_change_it') %></small>
   </div>
-
   <div class="form-group">
     <%= f.label :password_confirmation %>
     <%= f.password_field :password_confirmation, autocomplete: 'new-password', class: 'form-control'  %>
   </div>
-
   <div class="form-group">
     <%= f.label :current_password %>
     <%= f.password_field :current_password, autocomplete: 'current-password', class: 'form-control' %>
-
     <small class="form-text text-muted"><%= t('.we_need_your_current_password_to_confirm_your_changes') %></small>
   </div>
-
   <div class="form-group">
     <%= f.submit t('.update'), class: 'btn btn-primary btn-block' %>
   </div>
 <% end %>
-
 <%= link_to t('.cancel_my_account'), registration_path(resource_name), data: { confirm: t('.are_you_sure') }, method: :delete, class: 'btn btn-danger btn-block' %>
-
 <%= link_to t('.戻る'), :back, class: 'btn btn-secondary btn-block' %>

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -1,30 +1,27 @@
 <h1><%= t('.sign_up') %></h1>
-
 <%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
   <%= bootstrap_devise_error_messages! %>
-
   <div class="form-group">
     <%= f.label :email %>
     <%= f.email_field :email, autofocus: true, autocomplete: 'email', class: 'form-control' %>
   </div>
-
   <div class="form-group">
     <%= f.label :password %>
     <%= f.password_field :password, autocomplete: 'current-password', class: 'form-control' %>
-
     <% if @minimum_password_length %>
       <small class="form-text text-muted"><%= t('devise.shared.minimum_password_length', count: @minimum_password_length) %></small>
     <% end %>
   </div>
-
   <div class="form-group">
     <%= f.label :password_confirmation %>
     <%= f.password_field :password_confirmation, autocomplete: 'current-password', class: 'form-control' %>
   </div>
-
   <div class="form-group">
     <%= f.submit t('.sign_up'), class: 'btn btn-primary' %>
   </div>
 <% end %>
-
+<hr class="devise-link my-5">
+<div class="form-group">
+  <%= link_to "ゲストログイン（閲覧用）", users_guest_sign_in_path, method: :post, class: 'btn btn-success' %>
+</div>
 <%= render 'devise/shared/links' %>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -1,16 +1,13 @@
 <h1><%= t('.sign_in') %></h1>
-
 <%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
   <div class="form-group">
     <%= f.label :email %>
     <%= f.email_field :email, autofocus: true, autocomplete: 'email', class: 'form-control' %>
   </div>
-
   <div class="form-group">
     <%= f.label :password %>
     <%= f.password_field :password, autocomplete: 'current-password', class: 'form-control' %>
   </div>
-
   <% if devise_mapping.rememberable? %>
     <div class="form-group form-check">
       <%= f.check_box :remember_me, class: 'form-check-input' %>
@@ -19,10 +16,12 @@
       <% end %>
     </div>
   <% end %>
-
   <div class="form-group">
     <%= f.submit  t('.sign_in'), class: 'btn btn-primary' %>
   </div>
 <% end %>
-
+<hr class="devise-link my-5">
+<div class="form-group">
+  <%= link_to "ゲストログイン（閲覧用）", users_guest_sign_in_path, method: :post, class: 'btn btn-success' %>
+</div>
 <%= render 'devise/shared/links' %>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -3,45 +3,48 @@
     <%= image_tag("yanbaru_expert_logo.png")  %>
   </a>
   <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarNavDropdown" aria-controls="navbarNavDropdown" aria-expanded="false" aria-label="Toggle navigation">
-      <span class="navbar-toggler-icon"></span>
-    </button>
-    <div class="collapse navbar-collapse" id="navbarNavDropdown">
-      <ul class="navbar-nav">
-        <li class="nav-item dropdown">
-          <a class="nav-link dropdown-toggle" href="#" id="navbarDropdownMenuLink" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-            Ruby
-          </a>
-          <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-            <a class="dropdown-item" <%= link_to "Ruby/Railsテキスト教材", texts_path %></a>
+    <span class="navbar-toggler-icon"></span>
+  </button>
+  <div class="collapse navbar-collapse" id="navbarNavDropdown">
+    <ul class="navbar-nav">
+      <li class="nav-item dropdown">
+        <a class="nav-link dropdown-toggle" href="#" id="navbarDropdownMenuLink" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+          Ruby
+        </a>
+        <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
+          <a class="dropdown-item" <%= link_to "Ruby/Railsテキスト教材", texts_path %></a>
             <a class="dropdown-item" <%= link_to "Ruby/Rails動画教材", movies_path %></a>
-          </div>
-        </li>
-        <li class="nav-item dropdown">
-          <a class="nav-link dropdown-toggle" href="#" id="navbarDropdownMenuLink" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-            PHP
-          </a>
-          <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-            <a class="dropdown-item" <%= link_to "PHPテキスト教材", texts_path(genre: "php") %></a>
-            <a class="dropdown-item" <%= link_to "PHP動画教材", movies_path(genre: "php") %></a>
-          </div>
-        </li>
-        <% if user_signed_in? %>
-          <%# ログイン時 %>
-              <li class="nav-item">
-                <a class="nav-link" <%= link_to "アカウント編集", edit_user_registration_path %></a>
+            </div>
+          </li>
+          <li class="nav-item dropdown">
+            <a class="nav-link dropdown-toggle" href="#" id="navbarDropdownMenuLink" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+              PHP
+            </a>
+            <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
+              <a class="dropdown-item" <%= link_to "PHPテキスト教材", texts_path(genre: "php") %></a>
+                <a class="dropdown-item" <%= link_to "PHP動画教材", movies_path(genre: "php") %></a>
+                </div>
               </li>
-              <li class="nav-item">
-                <a class="nav-link" <%= link_to "ログアウト", destroy_user_session_path, method: :delete, data: { confirm: "ログアウトしますか？" } %></a>
-              </li>
-        <% else %>
-          <%# 非ログイン時 %>
-              <li class="nav-item">
-                <a class="nav-link" <%= link_to "新規登録", new_user_registration_path %></a>
-              </li>
-              <li class="nav-item">
-                <a class="nav-link" <%= link_to "ログイン", new_user_session_path %></a>
-              </li>
-        <% end %>
-      </ul>
-    </div>
-</nav>
+              <% if user_signed_in? %>
+                <%# ログイン時 %>
+                <li class="nav-item">
+                  <a class="nav-link" <%= link_to "アカウント編集", edit_user_registration_path %></a>
+                  </li>
+                  <li class="nav-item">
+                    <a class="nav-link" <%= link_to "ログアウト", destroy_user_session_path, method: :delete, data: { confirm: "ログアウトしますか？" } %></a>
+                    </li>
+                  <% else %>
+                    <%# 非ログイン時 %>
+                    <li class="nav-item">
+                      <a class="nav-link" <%= link_to "新規登録", new_user_registration_path %></a>
+                      </li>
+                      <li class="nav-item">
+                        <a class="nav-link" <%= link_to "ログイン", new_user_session_path %></a>
+                        </li>
+                        <li class="nav-item">
+                          <a class="nav-link" <%= link_to "ゲストログイン", users_guest_sign_in_path, method: :post %>
+                        </li>
+                          <% end %>
+                        </ul>
+                      </div>
+                    </nav>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,9 @@ Rails.application.routes.draw do
   ActiveAdmin.routes(self)
   devise_for :users
   root "texts#index"
+    devise_scope :user do
+  post "users/guest_sign_in", to: "users/sessions#guest_sign_in"
+  end
   resources :texts, only: [:index, :show]
   resources :movies, only: [:index]
 end


### PR DESCRIPTION
close #19

## 実装内容

#14 完了後に行って下さい

- ゲストログイン機能を実装
  - ナビバーと「ログイン・新規登録のページ」にも配置した方がよいでしょう
  - ゲストユーザーのメールアドレスは `test@example.com` とすること
  - ゲストユーザーを削除・更新されるケースへの対応は不要です
  - パスワード再設定機能は停止しているので対処不要です

## 参考文献

- [【やんばるエキスパート教材】ゲストログイン機能の実装](https://www.yanbaru-code.com/texts/392)

## 動作確認

- ゲストログインのリンク・ボタンからログインできることを確認

## チェックリスト

【補足】プルリクを出した後，クリックしてチェックを入れて下さい

- [x] GitHub で Files changed を確認
- [x] 影響し得る範囲のローカル環境での動作確認

## スクリーンショット（必要があれば）


## 備考（必要があれば）
