### PR TITLE
動画教材ページのジャンル分け

### DIFF
--- a/app/controllers/movies_controller.rb
+++ b/app/controllers/movies_controller.rb
@@ -1,9 +1,5 @@
 class MoviesController < ApplicationController
   def index
-    if params["genre"] == "php"
-      @movies = Movie.where(genre: Movie::PHP_GENRE_LIST)
-    else
-      @movies = Movie.where(genre: Movie::RAILS_GENRE_LIST)
-    end
+    @movies = Movie.filter_by(params[:genre])
   end
 end

--- a/app/controllers/movies_controller.rb
+++ b/app/controllers/movies_controller.rb
@@ -1,5 +1,9 @@
 class MoviesController < ApplicationController
   def index
-    @movies = Movie.where(genre: Movie::RAILS_GENRE_LIST)
+    if params["genre"] == "php"
+      @movies = Movie.where(genre: Movie::PHP_GENRE_LIST)
+    else
+      @movies = Movie.where(genre: Movie::RAILS_GENRE_LIST)
+    end
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -8,4 +8,12 @@ module ApplicationHelper
       "mw-xl"
     end
   end
+
+  def movie_title
+    if params["genre"] == "php"
+      "PHP 動画"
+    else
+      "Ruby/Rails 動画"
+    end
+  end
 end

--- a/app/models/movie.rb
+++ b/app/models/movie.rb
@@ -17,4 +17,11 @@ class Movie < ApplicationRecord
   RAILS_GENRE_LIST = %w[basic git ruby rails]
   PHP_GENRE_LIST = %w[php]
 
+  def self.filter_by(params)
+    if params == "php"
+      Movie.where(genre: Movie::PHP_GENRE_LIST)
+    else
+      Movie.where(genre: Movie::RAILS_GENRE_LIST)
+    end
+  end
 end

--- a/app/models/movie.rb
+++ b/app/models/movie.rb
@@ -17,8 +17,8 @@ class Movie < ApplicationRecord
   RAILS_GENRE_LIST = %w[basic git ruby rails]
   PHP_GENRE_LIST = %w[php]
 
-  def self.filter_by(params)
-    if params == "php"
+  def self.filter_by(genre)
+    if genre == "php"
       Movie.where(genre: Movie::PHP_GENRE_LIST)
     else
       Movie.where(genre: Movie::RAILS_GENRE_LIST)

--- a/app/models/movie.rb
+++ b/app/models/movie.rb
@@ -15,4 +15,6 @@ class Movie < ApplicationRecord
   }
 
   RAILS_GENRE_LIST = %w[basic git ruby rails]
+  PHP_GENRE_LIST = %w[php]
+
 end

--- a/app/views/movies/index.html.erb
+++ b/app/views/movies/index.html.erb
@@ -1,11 +1,10 @@
 <div class="container">
   <div class="row">
-    <h1 class="movie-title mt-2 mb-4">Ruby/Rails <br class="d-sm-none">
-      動画</h1>
+    <h1 class="movie-title mt-2 mb-4">  <br class="d-sm-none">
+     <%= movie_title %> </h1>
+
   </div>
 </div>
 <div class="row">
   <%= render partial: "movie", collection: @movies %>
 </div>
-
-


### PR DESCRIPTION
close #18 

## 実装内容

- PHP動画教材ページで「PHP動画教材のみ」が表示されるように修正
  - クエリパラメータ`?genre=php`を利用
  - モデルにクラスメソッドを作成して対応
- 「Ruby/Rails動画教材ページ」のタイトルは「Ruby/Rails 動画」，「PHP動画教材ページ」のタイトルは「PHP動画」とした
  - `app/helpers/application_helper.rb`にメソッドを作成して対応

## 参考資料

- [クエリパラメータについて](https://mseeeen.msen.jp/ruby-on-rails2/)
- [ヘルパーの使い方](https://qiita.com/sanstktkrsyhsk/items/67e9d88b939ccdcf46e8)

## チェックリスト


- [x] GitHub で Files changed を確認
- [x] 影響し得る範囲のローカル環境での動作確認
