### PR TITLE
動画教材のページネーションを実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,22 +3,23 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
 ruby '2.7.2'
 
-gem 'bootsnap', '>= 1.4.4', require: false
 gem 'activeadmin'
+gem 'bootsnap', '>= 1.4.4', require: false
 gem 'devise'
+gem 'devise-bootstrap-views', '~> 1.0'
 gem 'devise-i18n'
+gem 'enum_help'
 gem 'jbuilder', '~> 2.7'
+gem 'kaminari'
 gem 'pg', '~> 1.1'
 gem 'puma', '~> 5.0'
 gem 'rails', '~> 6.1.1'
 gem 'rails-i18n', '~> 6.0'
+gem 'redcarpet'
+gem 'rouge'
 gem 'sass-rails', '>= 6'
 gem 'turbolinks', '~> 5'
 gem 'webpacker', '~> 5.0'
-gem 'enum_help'
-gem 'devise-bootstrap-views', '~> 1.0'
-gem "redcarpet"
-gem "rouge"
 
 group :development, :test do
   gem 'byebug', platforms: %i[mri mingw x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -267,6 +267,7 @@ DEPENDENCIES
   devise-i18n
   enum_help
   jbuilder (~> 2.7)
+  kaminari
   listen (~> 3.3)
   pg (~> 1.1)
   pry-byebug

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -46,3 +46,7 @@ body {
 .alert-alert {
   @extend .alert-danger;
 }
+
+.pagination {
+  justify-content: center;
+}

--- a/app/controllers/movies_controller.rb
+++ b/app/controllers/movies_controller.rb
@@ -1,6 +1,7 @@
 class MoviesController < ApplicationController
+  PER_PAGE = 12
   def index
     # @movies = Movie.where(genre: Movie::RAILS_GENRE_LIST).page(params[:page]).per(12)
-    @movies = Movie.filter_by(params[:genre]).page(params[:page]).per(12)
+    @movies = Movie.filter_by(params[:genre]).page(params[:page]).per(PER_PAGE)
   end
 end

--- a/app/controllers/movies_controller.rb
+++ b/app/controllers/movies_controller.rb
@@ -1,5 +1,5 @@
 class MoviesController < ApplicationController
   def index
-    @movies = Movie.where(genre: Movie::RAILS_GENRE_LIST)
+    @movies = Movie.where(genre: Movie::RAILS_GENRE_LIST).page(params[:page]).per(12)
   end
 end

--- a/app/controllers/movies_controller.rb
+++ b/app/controllers/movies_controller.rb
@@ -1,6 +1,6 @@
 class MoviesController < ApplicationController
   def index
-    @movies = Movie.where(genre: Movie::RAILS_GENRE_LIST).page(params[:page]).per(12)
-    @movies = Movie.filter_by(params[:genre])
+    # @movies = Movie.where(genre: Movie::RAILS_GENRE_LIST).page(params[:page]).per(12)
+    @movies = Movie.filter_by(params[:genre]).page(params[:page]).per(12)
   end
 end

--- a/app/views/kaminari/_first_page.html.erb
+++ b/app/views/kaminari/_first_page.html.erb
@@ -1,0 +1,3 @@
+<li class="page-item">
+  <%= link_to_unless current_page.first?, raw(t 'views.pagination.first'), url, remote: remote, class: 'page-link' %>
+</li>

--- a/app/views/kaminari/_gap.html.erb
+++ b/app/views/kaminari/_gap.html.erb
@@ -1,0 +1,3 @@
+<li class='page-item disabled'>
+  <%= link_to raw(t 'views.pagination.truncate'), '#', class: 'page-link' %>
+</li>

--- a/app/views/kaminari/_last_page.html.erb
+++ b/app/views/kaminari/_last_page.html.erb
@@ -1,0 +1,3 @@
+<li class="page-item">
+  <%= link_to_unless current_page.last?, raw(t 'views.pagination.last'), url, remote: remote, class: 'page-link' %>
+</li>

--- a/app/views/kaminari/_next_page.html.erb
+++ b/app/views/kaminari/_next_page.html.erb
@@ -1,0 +1,3 @@
+<li class="page-item">
+  <%= link_to_unless current_page.last?, raw(t 'views.pagination.next'), url, rel: 'next', remote: remote, class: 'page-link' %>
+</li>

--- a/app/views/kaminari/_page.html.erb
+++ b/app/views/kaminari/_page.html.erb
@@ -1,0 +1,9 @@
+<% if page.current? %>
+  <li class="page-item active">
+    <%= content_tag :a, page, data: { remote: remote }, rel: page.rel, class: 'page-link' %>
+  </li>
+<% else %>
+  <li class="page-item">
+    <%= link_to page, url, remote: remote, rel: page.rel, class: 'page-link' %>
+  </li>
+<% end %>

--- a/app/views/kaminari/_paginator.html.erb
+++ b/app/views/kaminari/_paginator.html.erb
@@ -1,0 +1,17 @@
+<%= paginator.render do %>
+  <nav>
+    <ul class="pagination">
+      <%= first_page_tag unless current_page.first? %>
+      <%= prev_page_tag unless current_page.first? %>
+      <% each_page do |page| %>
+        <% if page.left_outer? || page.right_outer? || page.inside_window? %>
+          <%= page_tag page %>
+        <% elsif !page.was_truncated? -%>
+          <%= gap_tag %>
+        <% end %>
+      <% end %>
+      <%= next_page_tag unless current_page.last? %>
+      <%= last_page_tag unless current_page.last? %>
+    </ul>
+  </nav>
+<% end %>

--- a/app/views/kaminari/_prev_page.html.erb
+++ b/app/views/kaminari/_prev_page.html.erb
@@ -1,0 +1,3 @@
+<li class="page-item">
+  <%= link_to_unless current_page.first?, raw(t 'views.pagination.previous'), url, rel: 'prev', remote: remote, class: 'page-link' %>
+</li>

--- a/app/views/movies/_movie.html.erb
+++ b/app/views/movies/_movie.html.erb
@@ -7,8 +7,7 @@
     </div>
     <div class="card-body">
       <a href="#" class="btn btn-secondary btn-block">読破済みにする</a>
-      <h5 class="card-title mt-3"><%= "Lv.#{movie_counter + 1}：" %><%= movie.title %></h5>
-     
+      <h5 class="card-title mt-3"><%= "Lv.#{movie_counter + @movies.offset_value + 1 }：" %><%= movie.title %></h5>
     </div>
   </div>
 </div>

--- a/app/views/movies/_movie.html.erb
+++ b/app/views/movies/_movie.html.erb
@@ -8,6 +8,7 @@
     <div class="card-body">
       <a href="#" class="btn btn-secondary btn-block">読破済みにする</a>
       <h5 class="card-title mt-3"><%= "Lv.#{movie_counter + 1}：" %><%= movie.title %></h5>
+     
     </div>
   </div>
 </div>

--- a/app/views/movies/index.html.erb
+++ b/app/views/movies/index.html.erb
@@ -7,5 +7,5 @@
 <div class="row">
   <%= render partial: "movie", collection: @movies %>
 </div>
-
+ <%= paginate @movies %>
 


### PR DESCRIPTION

close #21

## 実装内容
- Gem `kaminari` をインストール
- 動画教材ページにページネーションを実装
  - 1ページの表示数は 12 件とすること
- 2ページ目以降のレベル表示を連番にする
  - `offset_value` を利用
- ページネーションに `Bootstrap` を適用 
```
rails g kaminari:views bootstrap4
```
- ページネーションを中央寄せにする
## 参考資料
- [【やんばるエキスパート教材】検索機能(Ransack)](https://www.yanbaru-code.com/texts/221)

## 動作確認
- Ruby/Rails動画 に ページネーション が付いていることを確認
- 動画の1ページの最大表示数が 12 であることを確認
- 2ページ目のレベル開始が 13 であることを確認
- ページネーションに Bootstrap のスタイルが適用され，中央寄せになっていることを確認
## チェックリスト

【補足】プルリクを出した後，クリックしてチェックを入れて下さい

- [x] GitHub で Files changed を確認
- [x] 影響し得る範囲のローカル環境での動作確認