### PR TITLE
テキスト教材ページのジャンル分け

### DIFF
--- a/app/controllers/texts_controller.rb
+++ b/app/controllers/texts_controller.rb
@@ -1,6 +1,6 @@
 class TextsController < ApplicationController
   def index
-    @texts = Text.filter_by(params[:genre])
+    @texts = Text.filter_by(params[:genre]).includes(:read_progresses)
   end
 
   def show

--- a/app/controllers/texts_controller.rb
+++ b/app/controllers/texts_controller.rb
@@ -1,7 +1,6 @@
-
 class TextsController < ApplicationController
   def index
-    @texts = Text.where(genre: Text::RAILS_GENRE_LIST)
+    @texts = Text.filter_by(params[:genre])
   end
 
   def show

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -17,12 +17,12 @@ module ApplicationHelper
     end
   end
 
-  def text_title
-    if params["genre"] == "php"
+  def php_text_title
+    if params[:genre] == "php"
       "PHP テキスト教材"
     else
       "Ruby/Rails テキスト教材"
     end
-  end
+end
 
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -2,27 +2,18 @@ module ApplicationHelper
   def max_width
     if controller_name == "texts" && action_name == "show"
       "mw-md"
-      elsif devise_controller?
-       "mw-sm"
+    elsif devise_controller?
+      "mw-sm"
     else
       "mw-xl"
     end
   end
 
-  def movie_title
+  def title
     if params["genre"] == "php"
-      "PHP 動画"
+      "PHP"
     else
-      "Ruby/Rails 動画"
+      "Ruby/Rails"
     end
   end
-
-  def php_text_title
-    if params[:genre] == "php"
-      "PHP テキスト教材"
-    else
-      "Ruby/Rails テキスト教材"
-    end
-end
-
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -16,4 +16,13 @@ module ApplicationHelper
       "Ruby/Rails 動画"
     end
   end
+
+  def text_title
+    if params["genre"] == "php"
+      "PHP テキスト教材"
+    else
+      "Ruby/Rails テキスト教材"
+    end
+  end
+
 end

--- a/app/models/text.rb
+++ b/app/models/text.rb
@@ -16,7 +16,7 @@ class Text < ApplicationRecord
 
   RAILS_GENRE_LIST = %w[basic git ruby rails].freeze
 
-  PHP_GENRE_LIST = %w[php]
+  PHP_GENRE_LIST = %w[php].freeze
 
   def self.filter_by(genre)
     if genre == "php"

--- a/app/models/text.rb
+++ b/app/models/text.rb
@@ -11,8 +11,18 @@ class Text < ApplicationRecord
     git: 2,
     ruby: 3,
     rails: 4,
-    php: 5
+    php: 5,
   }
-  
+
   RAILS_GENRE_LIST = %w[basic git ruby rails].freeze
+
+  PHP_GENRE_LIST = %w[php]
+
+  def self.filter_by(genre)
+    if genre == "php"
+      Text.where(genre: Text::PHP_GENRE_LIST)
+    else
+      Text.where(genre: Text::RAILS_GENRE_LIST)
+    end
+  end
 end

--- a/app/views/movies/index.html.erb
+++ b/app/views/movies/index.html.erb
@@ -1,8 +1,7 @@
 <div class="container">
   <div class="row">
-    <h1 class="movie-title mt-2 mb-4">  <br class="d-sm-none">
-     <%= movie_title %> </h1>
-
+    <h1 class="movie-title mt-2 mb-4"><%= title %> <br class="d-sm-none">
+      動画教材</h1>
   </div>
 </div>
 <div class="row">

--- a/app/views/texts/index.html.erb
+++ b/app/views/texts/index.html.erb
@@ -1,7 +1,7 @@
 <div class="container">
   <div class="row">
     <h1 class="text-title mt-2 mb-4">  <br class="d-sm-none">
-      <%= text_title %> </h1>
+      <%= php_text_title %> </h1>
   </div>
 </div>
 <div class="row">

--- a/app/views/texts/index.html.erb
+++ b/app/views/texts/index.html.erb
@@ -1,7 +1,7 @@
 <div class="container">
   <div class="row">
-    <h1 class="text-title mt-2 mb-4">  <br class="d-sm-none">
-      <%= php_text_title %> </h1>
+    <h1 class="text-title mt-2 mb-4"><%= title %> <br class="d-sm-none">
+      テキスト教材</h1>
   </div>
 </div>
 <div class="row">

--- a/app/views/texts/index.html.erb
+++ b/app/views/texts/index.html.erb
@@ -1,7 +1,7 @@
 <div class="container">
   <div class="row">
-    <h1 class="text-title mt-2 mb-4">Ruby/Rails <br class="d-sm-none">
-      テキスト教材</h1>
+    <h1 class="text-title mt-2 mb-4">  <br class="d-sm-none">
+      <%= text_title %> </h1>
   </div>
 </div>
 <div class="row">

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,11 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-<<<<<<< HEAD
 ActiveRecord::Schema.define(version: 2021_06_13_023542) do
-=======
-ActiveRecord::Schema.define(version: 2021_06_12_014058) do
->>>>>>> c3bfc1f68566ac92b5e11016c8abc67fc818df71
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -93,10 +89,8 @@ ActiveRecord::Schema.define(version: 2021_06_12_014058) do
     t.index ["user_id"], name: "index_watch_progresses_on_user_id"
   end
 
-  add_foreign_key "watch_progresses", "movies"
-  add_foreign_key "watch_progresses", "users"
-
   add_foreign_key "read_progresses", "texts"
   add_foreign_key "read_progresses", "users"
-
+  add_foreign_key "watch_progresses", "movies"
+  add_foreign_key "watch_progresses", "users"
 end


### PR DESCRIPTION
close #20  

## 実装内容

#13, #18 完了後に行って下さい

- PHPテキスト教材ページで「PHPのテキスト教材のみ」が表示されるように修正
  - `PHPテキスト教材` のリンクをクリックした際のクエリパラメータ `?genre=php` を利用
  - モデルにクラスメソッドを作成して対応

- 「Ruby/Railsテキスト教材ページ」のタイトルは「Ruby/Rails テキスト教材」，「PHPテキスト教材ページ」のタイトルは「PHP テキスト教材」とする
  - #18 の `app/helpers/application_helper.rb` にメソッドを作成して対応

## 動作確認

- 「Ruby/Railsテキスト教材」に「PHPテキスト教材」が含まれていないことを確認
- 「PHPテキスト教材」に「PHPテキスト教材」のみが表示されていることを確認
- クエリパラメータ `?genre=php` を `php` 以外に変更してアクセスした際は「Ruby/Railsテキスト教材」が表示されることを確認

## チェックリスト

- [x] GitHub で Files changed を確認
- [x] 影響し得る範囲のローカル環境での動作確認
