### PR TITLE
テキスト教材の読破済み機能

### DIFF
--- a/app/controllers/read_progresses_controller.rb
+++ b/app/controllers/read_progresses_controller.rb
@@ -1,0 +1,11 @@
+class ReadProgressesController < ApplicationController
+  def create
+    current_user.read_progresses.create!(text_id: params[:text_id])
+    redirect_back(fallback_location: root_path)
+  end
+
+  def destroy
+    current_user.read_progresses.find_by(text_id: params[:text_id]).destroy!
+    redirect_back(fallback_location: root_path)
+  end
+end

--- a/app/controllers/read_progresses_controller.rb
+++ b/app/controllers/read_progresses_controller.rb
@@ -2,12 +2,10 @@ class ReadProgressesController < ApplicationController
   def create
     @text = Text.find(params[:text_id])
     current_user.read_progresses.create!(text_id: @text.id)
-    # redirect_back(fallback_location: root_path)
   end
 
   def destroy
     @text = Text.find(params[:text_id])
     current_user.read_progresses.find_by(text_id: @text.id).destroy!
-    # redirect_back(fallback_location: root_path)
   end
 end

--- a/app/controllers/read_progresses_controller.rb
+++ b/app/controllers/read_progresses_controller.rb
@@ -1,11 +1,13 @@
 class ReadProgressesController < ApplicationController
   def create
-    current_user.read_progresses.create!(text_id: params[:text_id])
-    redirect_back(fallback_location: root_path)
+    @text = Text.find(params[:text_id])
+    current_user.read_progresses.create!(text_id: @text.id)
+    # redirect_back(fallback_location: root_path)
   end
 
   def destroy
-    current_user.read_progresses.find_by(text_id: params[:text_id]).destroy!
-    redirect_back(fallback_location: root_path)
+    @text = Text.find(params[:text_id])
+    current_user.read_progresses.find_by(text_id: @text.id).destroy!
+    # redirect_back(fallback_location: root_path)
   end
 end

--- a/app/controllers/texts_controller.rb
+++ b/app/controllers/texts_controller.rb
@@ -1,7 +1,7 @@
 
 class TextsController < ApplicationController
   def index
-    @texts = Text.where(genre: Text::RAILS_GENRE_LIST)
+    @texts = Text.where(genre: Text::RAILS_GENRE_LIST).includes(:read_progresses)
   end
 
   def show

--- a/app/models/read_progress.rb
+++ b/app/models/read_progress.rb
@@ -1,0 +1,4 @@
+class ReadProgress < ApplicationRecord
+  belongs_to :user
+  belongs_to :text
+end

--- a/app/models/read_progress.rb
+++ b/app/models/read_progress.rb
@@ -1,4 +1,8 @@
 class ReadProgress < ApplicationRecord
   belongs_to :user
   belongs_to :text
+  validates :user_id, uniqueness: {
+                        scope: :text_id,
+                        message: "は同じ教材に2回以上読破済みはできません"
+                      }
 end

--- a/app/models/read_progress.rb
+++ b/app/models/read_progress.rb
@@ -3,6 +3,6 @@ class ReadProgress < ApplicationRecord
   belongs_to :text
   validates :user_id, uniqueness: {
                         scope: :text_id,
-                        message: "は同じ教材に2回以上読破済みはできません"
+                        message: "は同じテキスト教材を2回以上読破済みにはできません"
                       }
 end

--- a/app/models/text.rb
+++ b/app/models/text.rb
@@ -1,9 +1,15 @@
 class Text < ApplicationRecord
   has_many :read_progresses, dependent: :destroy
+  # text.progressed_users で text を「読破済み」にしているユーザーの一覧を取得できるようになる
+  has_many :readprogressed_users, through: :read_progresses, source: :user
   with_options presence: true do
     validates :genre
     validates :title
     validates :content
+  end
+# text を user が「読破済み」しているときは「true」,「いいね」していないときは「false」
+  def readprogressed_by?(user)
+    read_progresses.any? { |read_progress| read_progress.user_id == user.id }
   end
 
   enum genre: {

--- a/app/models/text.rb
+++ b/app/models/text.rb
@@ -1,5 +1,5 @@
 class Text < ApplicationRecord
-  has_many :readprogresses, dependent: :destroy
+  has_many :read_progresses, dependent: :destroy
   with_options presence: true do
     validates :genre
     validates :title

--- a/app/models/text.rb
+++ b/app/models/text.rb
@@ -1,4 +1,5 @@
 class Text < ApplicationRecord
+  has_many :readprogresses, dependent: :destroy
   with_options presence: true do
     validates :genre
     validates :title
@@ -13,6 +14,6 @@ class Text < ApplicationRecord
     rails: 4,
     php: 5
   }
-  
+
   RAILS_GENRE_LIST = %w[basic git ruby rails].freeze
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,6 +2,8 @@ class User < ApplicationRecord
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   has_many :read_progresses, dependent: :destroy
+  # user.progressed_texts で user が「読破済み」にしているテキスト教材の一覧を取得できるようになる
+  has_many :readprogressed_texts, through: :read_progresses, source: :text
   devise :database_authenticatable, :registerable,
          :rememberable, :validatable
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,7 @@
 class User < ApplicationRecord
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
+  has_many :read_progresses, dependent: :destroy
   devise :database_authenticatable, :registerable,
          :rememberable, :validatable
 

--- a/app/views/read_progresses/create.js.erb
+++ b/app/views/read_progresses/create.js.erb
@@ -1,0 +1,1 @@
+document.getElementById('text-<%= @text.id %>').innerHTML = '<%= j render("texts/readprogress", text: @text) %>'

--- a/app/views/read_progresses/destroy.js.erb
+++ b/app/views/read_progresses/destroy.js.erb
@@ -1,0 +1,1 @@
+document.getElementById('text-<%= @text.id %>').innerHTML = '<%= j render("texts/unreadprogress", text: @text) %>'

--- a/app/views/texts/_readprogress.html.erb
+++ b/app/views/texts/_readprogress.html.erb
@@ -1,3 +1,2 @@
 <%# 読破済み（クリックすると「読破済み」解除） %>
 <%= link_to "読破済みを解除", text_read_progresses_path(text), class: "btn btn-primary btn-block", method: :delete, remote: true %>
-<%# data-remote="true" rel="nofollow" data-method="delete" href="#" %>

--- a/app/views/texts/_readprogress.html.erb
+++ b/app/views/texts/_readprogress.html.erb
@@ -1,0 +1,3 @@
+<%# 読破済み（クリックすると「読破済み」解除） %>
+<%= link_to "読破済みを解除", text_read_progresses_path(text), class: "btn btn-primary btn-block", method: :delete %>
+<%# data-remote="true" rel="nofollow" data-method="delete" href="#" %>

--- a/app/views/texts/_readprogress.html.erb
+++ b/app/views/texts/_readprogress.html.erb
@@ -1,3 +1,3 @@
 <%# 読破済み（クリックすると「読破済み」解除） %>
-<%= link_to "読破済みを解除", text_read_progresses_path(text), class: "btn btn-primary btn-block", method: :delete %>
+<%= link_to "読破済みを解除", text_read_progresses_path(text), class: "btn btn-primary btn-block", method: :delete, remote: true %>
 <%# data-remote="true" rel="nofollow" data-method="delete" href="#" %>

--- a/app/views/texts/_text.html.erb
+++ b/app/views/texts/_text.html.erb
@@ -8,7 +8,11 @@
       <div class="card-body">
       <%# TODO: 読破済みの部分のコードをobjectタグで囲み修正する %>
         <object>
-         <a class="btn btn-secondary btn-block" data-remote="true" rel="nofollow" data-method="post" href="#">読破済みにする</a>
+          <% if text.readprogressed_by?(current_user) %>
+            <%= render "readprogress", text: text %>
+          <% else %>
+            <%= render "unreadprogress", text: text %>
+          <% end %>
         </object>
         <h5 class="card-title mt-3"><%= text.title %></h5>
         <p class="card-genre">【<%= text.genre %>】</p>
@@ -16,7 +20,3 @@
     <% end %>
     </div>
   </div>
-  
-    
-
-

--- a/app/views/texts/_text.html.erb
+++ b/app/views/texts/_text.html.erb
@@ -8,11 +8,13 @@
       <div class="card-body">
       <%# TODO: 読破済みの部分のコードをobjectタグで囲み修正する %>
         <object>
+        <p id="text-<%= text.id %>">
           <% if text.readprogressed_by?(current_user) %>
             <%= render "readprogress", text: text %>
           <% else %>
             <%= render "unreadprogress", text: text %>
           <% end %>
+          </p>
         </object>
         <h5 class="card-title mt-3"><%= text.title %></h5>
         <p class="card-genre">【<%= text.genre %>】</p>

--- a/app/views/texts/_unreadprogress.html.erb
+++ b/app/views/texts/_unreadprogress.html.erb
@@ -1,0 +1,2 @@
+<%# 読破済み解除（クリックすると「読破済み」） %>
+<%= link_to "読破済みにする", text_read_progresses_path(text), class: "btn btn-secondary btn-block", method: :post %>

--- a/app/views/texts/_unreadprogress.html.erb
+++ b/app/views/texts/_unreadprogress.html.erb
@@ -1,2 +1,2 @@
 <%# 読破済み解除（クリックすると「読破済み」） %>
-<%= link_to "読破済みにする", text_read_progresses_path(text), class: "btn btn-secondary btn-block", method: :post %>
+<%= link_to "読破済みにする", text_read_progresses_path(text), class: "btn btn-secondary btn-block", method: :post, remote: true %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,8 @@ Rails.application.routes.draw do
     devise_scope :user do
   post "users/guest_sign_in", to: "users/sessions#guest_sign_in"
   end
-  resources :texts, only: [:index, :show]
+  resources :texts, only: [:index, :show] do
+    resource :read_progresses, only: [:create, :destroy]
+  end
   resources :movies, only: [:index]
 end

--- a/db/migrate/20210612014058_create_read_progresses.rb
+++ b/db/migrate/20210612014058_create_read_progresses.rb
@@ -1,0 +1,10 @@
+class CreateReadProgresses < ActiveRecord::Migration[6.1]
+  def change
+    create_table :read_progresses do |t|
+      t.references :user, null: false, foreign_key: true
+      t.references :text, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20210612014058_create_read_progresses.rb
+++ b/db/migrate/20210612014058_create_read_progresses.rb
@@ -6,5 +6,6 @@ class CreateReadProgresses < ActiveRecord::Migration[6.1]
 
       t.timestamps
     end
+    add_index :read_progresses, [:user_id, :text_id], unique: true
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_05_17_141131) do
+ActiveRecord::Schema.define(version: 2021_06_12_014058) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -49,6 +49,16 @@ ActiveRecord::Schema.define(version: 2021_05_17_141131) do
     t.datetime "updated_at", precision: 6, null: false
   end
 
+  create_table "read_progresses", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.bigint "text_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["text_id"], name: "index_read_progresses_on_text_id"
+    t.index ["user_id", "text_id"], name: "index_read_progresses_on_user_id_and_text_id", unique: true
+    t.index ["user_id"], name: "index_read_progresses_on_user_id"
+  end
+
   create_table "texts", force: :cascade do |t|
     t.integer "genre", default: 0, null: false
     t.string "title", null: false
@@ -69,4 +79,6 @@ ActiveRecord::Schema.define(version: 2021_05_17_141131) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  add_foreign_key "read_progresses", "texts"
+  add_foreign_key "read_progresses", "users"
 end


### PR DESCRIPTION
close #22 

## 実装内容
- 読破済み機能に使用する`ReadProgress`モデルを作成
  - 外部キー設定(`references`)を行い、ユニーク制約を入れてマイグレーション
  - バリデーションと関連付けをモデルに追加
- テキスト教材一覧ページに読破済み機能を実装
  - 非同期で処理(`js.erb`を使用)

## 参考資料
- [【やんばるエキスパート教材】モデルの関連付け その2（多対多）](https://www.yanbaru-code.com/texts/297)

## チェックリスト

【補足】プルリクを出した後，クリックしてチェックを入れて下さい

- [x] GitHub で Files changed を確認
- [x] 影響し得る範囲のローカル環境での動作確認