### PR TITLE
動画教材の読破済み機能を実装

### DIFF
--- a/app/controllers/movies_controller.rb
+++ b/app/controllers/movies_controller.rb
@@ -1,5 +1,5 @@
 class MoviesController < ApplicationController
   def index
-    @movies = Movie.where(genre: Movie::RAILS_GENRE_LIST)
+    @movies = Movie.includes(:watch_progresses).where(genre: Movie::RAILS_GENRE_LIST)
   end
 end

--- a/app/controllers/movies_controller.rb
+++ b/app/controllers/movies_controller.rb
@@ -1,6 +1,6 @@
 class MoviesController < ApplicationController
   PER_PAGE = 12
   def index
-    @movies = Movie.includes(:watch_progresses).where(genre: Movie::RAILS_GENRE_LIST).filter_by(params[:genre]).page(params[:page]).per(PER_PAGE)
+    @movies = Movie.where(genre: Movie::RAILS_GENRE_LIST).page(params[:page]).per(PER_PAGE).includes(:watch_progresses)
   end
 end

--- a/app/controllers/movies_controller.rb
+++ b/app/controllers/movies_controller.rb
@@ -1,6 +1,6 @@
 class MoviesController < ApplicationController
   PER_PAGE = 12
   def index
-    @movies = Movie.where(genre: Movie::RAILS_GENRE_LIST).page(params[:page]).per(PER_PAGE).includes(:watch_progresses)
+    @movies = Movie.filter_by(params[:genre]).page(params[:page]).per(PER_PAGE).includes(:watch_progresses)
   end
 end

--- a/app/controllers/watch_progresses_controller.rb
+++ b/app/controllers/watch_progresses_controller.rb
@@ -1,0 +1,11 @@
+class WatchProgressesController < ApplicationController
+  def create
+    @movie = Movie.find(params[:movie_id])
+    current_user.watch_progresses.create!(movie_id: @movie.id)
+  end
+
+  def destroy
+    @movie = Movie.find(params[:movie_id])
+    current_user.watch_progresses.find_by(movie_id: @movie.id).destroy!
+  end
+end

--- a/app/models/movie.rb
+++ b/app/models/movie.rb
@@ -1,4 +1,6 @@
 class Movie < ApplicationRecord
+  has_many :watch_progresses, dependent: :destroy
+
   with_options presence: true do
     validates :genre
     validates :title
@@ -15,4 +17,8 @@ class Movie < ApplicationRecord
   }
 
   RAILS_GENRE_LIST = %w[basic git ruby rails]
+
+  def watch_progressed_by?(user)
+    watch_progresses.any? { |watch_progress| watch_progress.user_id == user.id }
+  end
 end

--- a/app/models/movie.rb
+++ b/app/models/movie.rb
@@ -1,6 +1,6 @@
 class Movie < ApplicationRecord
   has_many :watch_progresses, dependent: :destroy
-
+  has_many :watch_progressed_users, through: :watch_progresseses, source: :user
   with_options presence: true do
     validates :genre
     validates :title

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,8 @@
 class User < ApplicationRecord
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
+  has_many :watch_progresses, dependent: :destroy
+
   devise :database_authenticatable, :registerable,
          :rememberable, :validatable
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,7 +2,7 @@ class User < ApplicationRecord
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   has_many :watch_progresses, dependent: :destroy
-
+  has_many :watch_progressed_movies, through: :watch_progresses, source: :movie
   devise :database_authenticatable, :registerable,
          :rememberable, :validatable
 

--- a/app/models/watch_progress.rb
+++ b/app/models/watch_progress.rb
@@ -1,0 +1,8 @@
+class WatchProgress < ApplicationRecord
+  belongs_to :user
+  belongs_to :movie
+  validates :user_id, uniqueness: {
+    scope: :movie_id,
+    message: "は同じ投稿に2回以上試聴済みはできません"
+  }
+end

--- a/app/models/watch_progress.rb
+++ b/app/models/watch_progress.rb
@@ -3,6 +3,6 @@ class WatchProgress < ApplicationRecord
   belongs_to :movie
   validates :user_id, uniqueness: {
     scope: :movie_id,
-    message: "は同じ投稿に2回以上試聴済みはできません"
+    message: "は同じ投稿に2回以上視聴済みはできません"
   }
 end

--- a/app/views/movies/_diswatch_progress.html.erb
+++ b/app/views/movies/_diswatch_progress.html.erb
@@ -1,0 +1,1 @@
+<%= link_to "視聴済みにする", movie_watch_progresses_path(movie), class: "btn btn-secondary btn-block", method: :post, remote: true %>

--- a/app/views/movies/_movie.html.erb
+++ b/app/views/movies/_movie.html.erb
@@ -1,13 +1,19 @@
 <div class="card-box col-12 col-md-6 col-lg-4">
   <div class="card content-card border-dark mb-3">
     <div class="card-header p-0">
-      <div class="embed-responsive embed-responsive-16by9">  
+      <div class="embed-responsive embed-responsive-16by9">
         <%= embed_youtube(movie.url) %>
       </div>
     </div>
     <div class="card-body">
-      <a href="#" class="btn btn-secondary btn-block">読破済みにする</a>
-      <h5 class="card-title mt-3"><%= "Lv.#{movie_counter + 1}：" %><%= movie.title %></h5>
+      <p id="movie-<%= movie.id %>" >
+        <% if movie.watch_progressed_by?(current_user) %>
+          <%= render "watch_progress", movie: movie %>
+        <% else %>
+          <%= render "diswatch_progress", movie: movie %>
+        <% end %>
+      </p>
+      <p class="card-title mt-3"><%= "Lv.#{movie_counter + 1}：" %><%= movie.title %></p>
     </div>
   </div>
 </div>

--- a/app/views/movies/_watch_progress.html.erb
+++ b/app/views/movies/_watch_progress.html.erb
@@ -1,0 +1,1 @@
+<%= link_to "視聴済みを解除", movie_watch_progresses_path(movie), class: "btn btn-primary btn-block", method: :delete, remote: true %>

--- a/app/views/watch_progresses/create.js.erb
+++ b/app/views/watch_progresses/create.js.erb
@@ -1,0 +1,1 @@
+document.getElementById('movie-<%= @movie.id %>').innerHTML = '<%= j render("movies/watch_progress", movie: @movie) %>'

--- a/app/views/watch_progresses/destroy.js.erb
+++ b/app/views/watch_progresses/destroy.js.erb
@@ -1,0 +1,1 @@
+document.getElementById('movie-<%= @movie.id %>').innerHTML = '<%= j render("movies/diswatch_progress", movie: @movie) %>'

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -13,6 +13,7 @@ ja:
     models:
       text: テキスト教材
       movie: 動画教材
+      watch_progress: 視聴済み
     attributes:
       text:
         genre: ジャンル
@@ -22,3 +23,6 @@ ja:
         genre: ジャンル
         title: タイトル
         url: URL
+      watch_progress:
+        user: ユーザー
+        movie: 動画教材

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,7 +7,7 @@ Rails.application.routes.draw do
   post "users/guest_sign_in", to: "users/sessions#guest_sign_in"
   end
   resources :texts, only: [:index, :show]
-  resources :movies do
+  resources :movies, only: [:index] do 
     resource :watch_progresses, only: [:create, :destroy]
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,5 +7,7 @@ Rails.application.routes.draw do
   post "users/guest_sign_in", to: "users/sessions#guest_sign_in"
   end
   resources :texts, only: [:index, :show]
-  resources :movies, only: [:index]
+  resources :movies do
+    resource :watch_progresses, only: [:create, :destroy]
+  end
 end

--- a/db/migrate/20210613023542_create_watch_progresses.rb
+++ b/db/migrate/20210613023542_create_watch_progresses.rb
@@ -1,0 +1,11 @@
+class CreateWatchProgresses < ActiveRecord::Migration[6.1]
+  def change
+    create_table :watch_progresses do |t|
+      t.references :user, null: false, foreign_key: true
+      t.references :movie, null: false, foreign_key: true
+
+      t.timestamps
+    end
+    add_index :watch_progresses, [:user_id, :movie_id], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_05_17_141131) do
+ActiveRecord::Schema.define(version: 2021_06_13_023542) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -69,4 +69,16 @@ ActiveRecord::Schema.define(version: 2021_05_17_141131) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  create_table "watch_progresses", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.bigint "movie_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["movie_id"], name: "index_watch_progresses_on_movie_id"
+    t.index ["user_id", "movie_id"], name: "index_watch_progresses_on_user_id_and_movie_id", unique: true
+    t.index ["user_id"], name: "index_watch_progresses_on_user_id"
+  end
+
+  add_foreign_key "watch_progresses", "movies"
+  add_foreign_key "watch_progresses", "users"
 end


### PR DESCRIPTION
close #23

## 実装内容

#15 完了後に行って下さい

- 視聴済み機能に使用する `WatchProgress` モデルを作成
  - 外部キー設定を行い，ユニーク制約を入れてからマイグレーション
  - バリデーションをモデルに追加
  - 関連付けを入れる（`User` と `Movie` の関連付けは使用しないので入れなくてもOK）
  - 初期データの実装は不要です

（この時点で下記の動作確認を行ってみましょう）

- 動画教材一覧ページに視聴済み機能を実装
  - 非同期で処理できるようにすること

## 参考文献

- [【やんばるエキスパート教材】モデルの関連付け その2（多対多）](https://www.yanbaru-code.com/texts/297)

## 動作確認

- 以下を確認

```zsh
rails c -s

# Railsコンソール起動後
user = User.first
movie, movie2 = Movie.limit(2)
WatchProgress.delete_all

user.watch_progresses.create!(movie_id: movie.id)
user.watch_progresses.create!(movie_id: movie2.id)

WatchProgress.count
#=> 2

movie.watch_progresses.create!(user_id: user.id)
#=> ActiveRecord::RecordInvalid: バリデーションに失敗しました: Userは同じ動画教材を2回以上視聴済みにはできません

WatchProgress.create!
#=> ActiveRecord::RecordInvalid: バリデーションに失敗しました: ユーザーを入力してください, 動画教材を入力してください
```

- 動画教材一覧ページの視聴済み機能が動作していることを確認


## チェックリスト

【補足】プルリクを出した後，クリックしてチェックを入れて下さい

- [x] GitHub で Files changed を確認
- [x] 影響し得る範囲のローカル環境での動作確認