### PR TITLE
管理者画面から教材を編集できるように修正

### DIFF
--- a/app/admin/movies.rb
+++ b/app/admin/movies.rb
@@ -1,4 +1,5 @@
 ActiveAdmin.register Movie do
+  permit_params :genre, :title, :url
 
   index do
     selectable_column
@@ -18,20 +19,7 @@ ActiveAdmin.register Movie do
     end
     f.actions
   end
-  # See permitted parameters documentation:
-  # https://github.com/activeadmin/activeadmin/blob/master/docs/2-resource-customization.md#setting-up-strong-parameters
-  #
-  # Uncomment all parameters which should be permitted for assignment
-  #
-  # permit_params :genre, :title, :url
-  #
-  # or
-  #
-  permit_params do
-    permitted = [:genre, :title, :url]
-  #   permitted << :other if params[:action] == 'create' && current_user.admin?
-  #   permitted
-  end
+
   filter :genre, as: :select, collection: Movie.genres_i18n.invert.transform_values { |v| Movie.genres[v] }
   filter :title
   filter :url

--- a/app/admin/movies.rb
+++ b/app/admin/movies.rb
@@ -27,11 +27,11 @@ ActiveAdmin.register Movie do
   #
   # or
   #
-  # permit_params do
-  #   permitted = [:genre, :title, :url]
+  permit_params do
+    permitted = [:genre, :title, :url]
   #   permitted << :other if params[:action] == 'create' && current_user.admin?
   #   permitted
-  # end
+  end
   filter :genre, as: :select, collection: Movie.genres_i18n.invert.transform_values { |v| Movie.genres[v] }
   filter :title
   filter :url

--- a/app/admin/texts.rb
+++ b/app/admin/texts.rb
@@ -1,6 +1,6 @@
 ActiveAdmin.register Text do
+  permit_params :genre, :title, :content
 
-  # permit_params :genre, :title
   index do
     selectable_column
     id_column
@@ -19,20 +19,7 @@ ActiveAdmin.register Text do
     end
     f.actions
   end
-  # See permitted parameters documentation:
-  # https://github.com/activeadmin/activeadmin/blob/master/docs/2-resource-customization.md#setting-up-strong-parameters
-  #
-  # Uncomment all parameters which should be permitted for assignment
-  #
-  # permit_params :genre, :title, :content
-  #
-  # or
-  #
-  permit_params do
-    permitted = [:genre, :title, :content]
-  #   permitted << :other if params[:action] == 'create' && current_user.admin?
-  #   permitted
-  end
+
   filter :genre, as: :select, collection: Text.genres_i18n.invert.transform_values { |v| Text.genres[v] }
   filter :title
   filter :content

--- a/app/admin/texts.rb
+++ b/app/admin/texts.rb
@@ -28,11 +28,11 @@ ActiveAdmin.register Text do
   #
   # or
   #
-  # permit_params do
-  #   permitted = [:genre, :title, :content]
+  permit_params do
+    permitted = [:genre, :title, :content]
   #   permitted << :other if params[:action] == 'create' && current_user.admin?
   #   permitted
-  # end
+  end
   filter :genre, as: :select, collection: Text.genres_i18n.invert.transform_values { |v| Text.genres[v] }
   filter :title
   filter :content

--- a/app/admin/users.rb
+++ b/app/admin/users.rb
@@ -35,7 +35,7 @@ ActiveAdmin.register User do
   # or
   #
   # permit_params do
-  #   permitted = [:email, :encrypted_password, :reset_password_token, :reset_password_sent_at, :remember_created_at]
+    # permitted = [:email, :encrypted_password, :reset_password_token, :reset_password_sent_at, :remember_created_at]
   #   permitted << :other if params[:action] == 'create' && current_user.admin?
   #   permitted
   # end

--- a/app/admin/users.rb
+++ b/app/admin/users.rb
@@ -1,20 +1,15 @@
 ActiveAdmin.register User do
-
   permit_params :email, :password, :password_confirmation
 
   index do
     selectable_column
     id_column
     column :email
-    # column :current_sign_in_at
-    # column :sign_in_count
     column :created_at
     actions
   end
 
   filter :email
-  # filter :current_sign_in_at
-  # filter :sign_in_count
   filter :created_at
 
   form do |f|
@@ -25,19 +20,5 @@ ActiveAdmin.register User do
     end
     f.actions
   end
-  # See permitted parameters documentation:
-  # https://github.com/activeadmin/activeadmin/blob/master/docs/2-resource-customization.md#setting-up-strong-parameters
-  #
-  # Uncomment all parameters which should be permitted for assignment
-  #
-  # permit_params :email, :encrypted_password, :reset_password_token, :reset_password_sent_at, :remember_created_at
-  #
-  # or
-  #
-  # permit_params do
-    # permitted = [:email, :encrypted_password, :reset_password_token, :reset_password_sent_at, :remember_created_at]
-  #   permitted << :other if params[:action] == 'create' && current_user.admin?
-  #   permitted
-  # end
 
 end


### PR DESCRIPTION
close #52 

## 実装内容
- 管理者画面より教材を編集・修正できるようにする
  - `movies.rb`と`texts.rb`の以下のコメントアウトを表示
  ```Ruby
  permit_params do
    permitted = [:genre, :title, :url]
  end
  ```

## 参考資料
- [ストロングパラメータについて(ActiveAdmin)](https://qiita.com/yusabana/items/78e8d1ed64ead5fe9e29)

## チェックリスト

【補足】プルリクを出した後，クリックしてチェックを入れて下さい

- [x] GitHub で Files changed を確認
- [x] 影響し得る範囲のローカル環境での動作確認